### PR TITLE
chore: update LICENSE and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ testbench.yaml
 /docs
 /coverage
 CLAUDE.md
+.DS_Store

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Lettermint V.O.F.
+Copyright (c) Lettermint B.V.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated copyright in LICENSE to "Lettermint B.V." and added `.DS_Store` to `.gitignore` for improved repository hygiene.