### PR TITLE
feat: add message.policy_rejected webhook event. Fixes #27

### DIFF
--- a/src/Events/MessagePolicyRejected.php
+++ b/src/Events/MessagePolicyRejected.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Lettermint\Laravel\Events;
+
+use Lettermint\Laravel\Webhooks\Data\MessagePolicyRejectedData;
+use Lettermint\Laravel\Webhooks\Data\WebhookEnvelope;
+
+final class MessagePolicyRejected extends LettermintWebhookEvent
+{
+    public function __construct(
+        public readonly WebhookEnvelope $envelope,
+        public readonly MessagePolicyRejectedData $data,
+    ) {}
+
+    public function getEnvelope(): WebhookEnvelope
+    {
+        return $this->envelope;
+    }
+}

--- a/src/Webhooks/Data/MessagePolicyRejectedData.php
+++ b/src/Webhooks/Data/MessagePolicyRejectedData.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Lettermint\Laravel\Webhooks\Data;
+
+final readonly class MessagePolicyRejectedData
+{
+    /**
+     * @param  array<int, SpamSymbol>  $spamSymbols
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public string $messageId,
+        public string $subject,
+        public string $reason,
+        public float $score,
+        public array $spamSymbols,
+        public array $metadata,
+        public ?string $tag,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            messageId: $data['message_id'],
+            subject: $data['subject'],
+            reason: $data['reason'],
+            score: (float) $data['score'],
+            spamSymbols: array_map(
+                fn (array $symbol): SpamSymbol => SpamSymbol::fromArray($symbol),
+                $data['spam_symbols'] ?? [],
+            ),
+            metadata: $data['metadata'] ?? [],
+            tag: $data['tag'] ?? null,
+        );
+    }
+}

--- a/src/Webhooks/WebhookEventType.php
+++ b/src/Webhooks/WebhookEventType.php
@@ -8,6 +8,7 @@ use Lettermint\Laravel\Events\MessageDelivered;
 use Lettermint\Laravel\Events\MessageFailed;
 use Lettermint\Laravel\Events\MessageHardBounced;
 use Lettermint\Laravel\Events\MessageInbound;
+use Lettermint\Laravel\Events\MessagePolicyRejected;
 use Lettermint\Laravel\Events\MessageSent;
 use Lettermint\Laravel\Events\MessageSoftBounced;
 use Lettermint\Laravel\Events\MessageSpamComplaint;
@@ -19,6 +20,7 @@ use Lettermint\Laravel\Webhooks\Data\MessageDeliveredData;
 use Lettermint\Laravel\Webhooks\Data\MessageFailedData;
 use Lettermint\Laravel\Webhooks\Data\MessageHardBouncedData;
 use Lettermint\Laravel\Webhooks\Data\MessageInboundData;
+use Lettermint\Laravel\Webhooks\Data\MessagePolicyRejectedData;
 use Lettermint\Laravel\Webhooks\Data\MessageSentData;
 use Lettermint\Laravel\Webhooks\Data\MessageSoftBouncedData;
 use Lettermint\Laravel\Webhooks\Data\MessageSpamComplaintData;
@@ -39,6 +41,7 @@ enum WebhookEventType: string
     case MessageSuppressed = 'message.suppressed';
     case MessageUnsubscribed = 'message.unsubscribed';
     case MessageInbound = 'message.inbound';
+    case MessagePolicyRejected = 'message.policy_rejected';
     case WebhookTest = 'webhook.test';
 
     public function isBounce(): bool
@@ -53,6 +56,7 @@ enum WebhookEventType: string
             self::MessageSoftBounced,
             self::MessageFailed,
             self::MessageSuppressed,
+            self::MessagePolicyRejected,
         ], true);
     }
 
@@ -77,6 +81,7 @@ enum WebhookEventType: string
             self::MessageSuppressed => new MessageSuppressed($envelope, MessageSuppressedData::fromArray($data)),
             self::MessageUnsubscribed => new MessageUnsubscribed($envelope, MessageUnsubscribedData::fromArray($data)),
             self::MessageInbound => new MessageInbound($envelope, MessageInboundData::fromArray($data)),
+            self::MessagePolicyRejected => new MessagePolicyRejected($envelope, MessagePolicyRejectedData::fromArray($data)),
             self::WebhookTest => new WebhookTest($envelope, WebhookTestData::fromArray($data)),
         };
     }

--- a/tests/Unit/Webhooks/WebhookEventTypeTest.php
+++ b/tests/Unit/Webhooks/WebhookEventTypeTest.php
@@ -5,6 +5,7 @@ use Lettermint\Laravel\Events\MessageDelivered;
 use Lettermint\Laravel\Events\MessageFailed;
 use Lettermint\Laravel\Events\MessageHardBounced;
 use Lettermint\Laravel\Events\MessageInbound;
+use Lettermint\Laravel\Events\MessagePolicyRejected;
 use Lettermint\Laravel\Events\MessageSent;
 use Lettermint\Laravel\Events\MessageSoftBounced;
 use Lettermint\Laravel\Events\MessageSpamComplaint;
@@ -24,6 +25,7 @@ it('can create event type from string value', function () {
     expect(WebhookEventType::from('message.suppressed'))->toBe(WebhookEventType::MessageSuppressed);
     expect(WebhookEventType::from('message.unsubscribed'))->toBe(WebhookEventType::MessageUnsubscribed);
     expect(WebhookEventType::from('message.inbound'))->toBe(WebhookEventType::MessageInbound);
+    expect(WebhookEventType::from('message.policy_rejected'))->toBe(WebhookEventType::MessagePolicyRejected);
     expect(WebhookEventType::from('webhook.test'))->toBe(WebhookEventType::WebhookTest);
 });
 
@@ -39,6 +41,7 @@ it('identifies delivery issue event types', function () {
     expect(WebhookEventType::MessageSoftBounced->isDeliveryIssue())->toBeTrue();
     expect(WebhookEventType::MessageFailed->isDeliveryIssue())->toBeTrue();
     expect(WebhookEventType::MessageSuppressed->isDeliveryIssue())->toBeTrue();
+    expect(WebhookEventType::MessagePolicyRejected->isDeliveryIssue())->toBeTrue();
     expect(WebhookEventType::MessageDelivered->isDeliveryIssue())->toBeFalse();
     expect(WebhookEventType::MessageSent->isDeliveryIssue())->toBeFalse();
 });
@@ -189,6 +192,21 @@ it('creates correct event class for each type', function (string $eventType, str
             'spam_score' => 0,
             'spam_symbols' => [],
         ],
+        'message.policy_rejected' => [
+            'message_id' => 'msg-123',
+            'subject' => 'Limited time offer!!!',
+            'reason' => 'Spam score threshold exceeded',
+            'score' => 7.5,
+            'spam_symbols' => [
+                [
+                    'name' => 'BAYES_SPAM',
+                    'score' => 3.5,
+                    'options' => [],
+                    'description' => 'Bayes spam probability is very high',
+                ],
+            ],
+            'metadata' => [],
+        ],
         'webhook.test' => [
             'message' => 'Test',
             'webhook_id' => 'webhook-123',
@@ -217,5 +235,6 @@ it('creates correct event class for each type', function (string $eventType, str
     ['message.suppressed', MessageSuppressed::class],
     ['message.unsubscribed', MessageUnsubscribed::class],
     ['message.inbound', MessageInbound::class],
+    ['message.policy_rejected', MessagePolicyRejected::class],
     ['webhook.test', WebhookTest::class],
 ]);


### PR DESCRIPTION
Adds support for the `message.policy_rejected` webhook event, documented at:
https://lettermint.co/docs/platform/webhooks/events#messagepolicy_rejected

The event is sent when Lettermint blocks an outgoing message before delivery because its internal spam score exceeded the threshold. The payload includes the spam score, a human-readable reason and the list of matched spam rules.

## Changes

- `WebhookEventType::MessagePolicyRejected` enum case (`message.policy_rejected`)
- `isDeliveryIssue()` returns true for this case — the message was not delivered
- `MessagePolicyRejected` event + `MessagePolicyRejectedData` payload class, re-using the existing `SpamSymbol` data class
- Test coverage added in `WebhookEventTypeTest` (string-from, isDeliveryIssue, data-driven event construction)

## Test plan

- [x] `vendor/bin/pest` — 78 tests pass, 371 assertions
- [x] `vendor/bin/pint --dirty` — clean