### PR TITLE
Make API request timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Add your Lettermint API token in your `.env` file when you want to use the Team 
 LETTERMINT_API_TOKEN=your-lettermint-api-token
 ```
 
+### Setting the request timeout
+
+The default Lettermint API request timeout is 15 seconds. You can override it in your `.env` file:
+
+```env
+LETTERMINT_TIMEOUT=30
+```
+
 ### Add the transport
 
 In your `config/mail.php`, set the default option to lettermint:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^10.0 | ^11.0 | ^12.0 | ^13.0",
-        "lettermint/lettermint-php": "^2.0",
+        "lettermint/lettermint-php": "^2.1",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {

--- a/config/lettermint.php
+++ b/config/lettermint.php
@@ -37,7 +37,7 @@ return [
     |
     */
 
-    'request_timeout' => (int) env('LETTERMINT_REQUEST_TIMEOUT', 15),
+    'timeout' => (int) env('LETTERMINT_TIMEOUT', 15),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/lettermint.php
+++ b/config/lettermint.php
@@ -28,6 +28,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Request Timeout
+    |--------------------------------------------------------------------------
+    |
+    | The maximum number of seconds to wait for a response from the Lettermint
+    | API before timing out. Increase this if you send large batch requests
+    | that occasionally need longer than the default to be accepted.
+    |
+    */
+
+    'request_timeout' => (int) env('LETTERMINT_REQUEST_TIMEOUT', 15),
+
+    /*
+    |--------------------------------------------------------------------------
     | Webhooks Configuration
     |--------------------------------------------------------------------------
     |

--- a/src/LettermintServiceProvider.php
+++ b/src/LettermintServiceProvider.php
@@ -50,7 +50,7 @@ class LettermintServiceProvider extends PackageServiceProvider
                 throw ApiTokenNotFoundException::create();
             }
 
-            return LettermintSdk::email($projectToken);
+            return LettermintSdk::email($projectToken, timeout: (int) config('lettermint.request_timeout', 15));
         });
         $this->app->alias(EmailEndpoint::class, 'lettermint');
     }
@@ -64,7 +64,7 @@ class LettermintServiceProvider extends PackageServiceProvider
                 throw TeamApiTokenNotFoundException::create();
             }
 
-            return LettermintSdk::api($apiToken);
+            return LettermintSdk::api($apiToken, timeout: (int) config('lettermint.request_timeout', 15));
         });
         $this->app->alias(ApiClient::class, 'lettermint.api');
     }

--- a/src/LettermintServiceProvider.php
+++ b/src/LettermintServiceProvider.php
@@ -50,7 +50,7 @@ class LettermintServiceProvider extends PackageServiceProvider
                 throw ApiTokenNotFoundException::create();
             }
 
-            return LettermintSdk::email($projectToken, timeout: (int) config('lettermint.request_timeout', 15));
+            return LettermintSdk::email($projectToken, timeout: self::requestTimeout());
         });
         $this->app->alias(EmailEndpoint::class, 'lettermint');
     }
@@ -64,9 +64,14 @@ class LettermintServiceProvider extends PackageServiceProvider
                 throw TeamApiTokenNotFoundException::create();
             }
 
-            return LettermintSdk::api($apiToken, timeout: (int) config('lettermint.request_timeout', 15));
+            return LettermintSdk::api($apiToken, timeout: self::requestTimeout());
         });
         $this->app->alias(ApiClient::class, 'lettermint.api');
+    }
+
+    private static function requestTimeout(): int
+    {
+        return (int) config('lettermint.timeout', 15);
     }
 
     public function provides(): array

--- a/tests/Feature/LettermintServiceProviderTest.php
+++ b/tests/Feature/LettermintServiceProviderTest.php
@@ -75,6 +75,15 @@ it('uses legacy token from lettermint config', function () {
     expect($email)->toBeInstanceOf(EmailEndpoint::class);
 });
 
+it('passes configured request timeout to the email sdk client', function () {
+    config()->set('lettermint.token', 'test-token');
+    config()->set('lettermint.timeout', 42);
+
+    $email = app()->get(EmailEndpoint::class);
+
+    expect(sdkRequestTimeout($email))->toBe(42);
+});
+
 it('provides the lettermint api client binding', function () {
     config()->set('lettermint.api_token', 'team-api-token');
 
@@ -95,6 +104,15 @@ it('prefers lettermint api token over services api token', function () {
     config()->set('services.lettermint.api_token', 'team-api-token-from-services');
 
     expect(app()->get(ApiClient::class))->toBeInstanceOf(ApiClient::class);
+});
+
+it('passes configured request timeout to the api sdk client', function () {
+    config()->set('lettermint.api_token', 'team-api-token');
+    config()->set('lettermint.timeout', 42);
+
+    $api = app()->get(ApiClient::class);
+
+    expect(sdkRequestTimeout($api))->toBe(42);
 });
 
 it('throws exception when no api token is configured', function () {
@@ -140,3 +158,26 @@ it('passes route_id configuration to transport when using full mail config', fun
     expect($config)->toHaveKey('route_id');
     expect($config['route_id'])->toBe('broadcast');
 });
+
+function sdkRequestTimeout(object $sdkObject): int|float
+{
+    $httpClient = sdkHttpClient($sdkObject);
+
+    $httpClientReflection = new ReflectionClass($httpClient);
+    $guzzleClientProperty = $httpClientReflection->getProperty('client');
+    $guzzleClientProperty->setAccessible(true);
+    $guzzleClient = $guzzleClientProperty->getValue($httpClient);
+
+    return $guzzleClient->getConfig('timeout');
+}
+
+function sdkHttpClient(object $sdkObject): object
+{
+    $sdkReflection = new ReflectionClass($sdkObject);
+    $httpClientProperty = $sdkReflection->hasProperty('httpClient')
+        ? $sdkReflection->getProperty('httpClient')
+        : $sdkReflection->getParentClass()->getProperty('httpClient');
+    $httpClientProperty->setAccessible(true);
+
+    return $httpClientProperty->getValue($sdkObject);
+}


### PR DESCRIPTION
Exposes the configurable HTTP timeout from the SDK (see lettermint/lettermint-php#25) as a Laravel config value.

## Change

- New config key `request_timeout`, driven by `LETTERMINT_REQUEST_TIMEOUT` (default `15`)
- Passed to `LettermintSdk::email()` and `LettermintSdk::api()` so it reaches the underlying Guzzle client

```php
// config/lettermint.php
"request_timeout" => (int) env("LETTERMINT_REQUEST_TIMEOUT", 15),
```

## Why

Large `POST /v1/send/batch` requests occasionally need longer than the hardcoded 15s to be accepted, causing `cURL error 28`. This lets applications raise the timeout per environment.

## ⚠️ Depends on lettermint/lettermint-php#25

This uses the `timeout:` named argument added in lettermint/lettermint-php#25. Opened as a **draft** — it needs that PR released and the `lettermint/lettermint-php` constraint bumped to the release that contains it before CI will pass / it can be merged.